### PR TITLE
Make stdout the default output destination for all types

### DIFF
--- a/sca/controller.py
+++ b/sca/controller.py
@@ -56,24 +56,28 @@ def run_sca(binary_path, binary_args, sca_options):
         group_problems = core.run_xml_match(jour_file)
 
         if not group_problems:
-            sys.stdout.write("\nSCA report: No reports found.")
+            sys.stdout.write("\nSCA report: No reports found.\n")
             sys.exit(0)
 
-	if sca_options.get_file_type_opt() is None:
-		sca_options.set_file_type_opt('txt')
+        if sca_options.get_file_type_opt() is None:
+            sca_options.set_file_type_opt('txt')
 
-	output_type = sca_options.get_file_type_opt()
+        output_type = sca_options.get_file_type_opt()
 
-	if output_type == 'txt':
-		if sca_options.get_color_opt():
-			output_type = 'color'
+        if output_type == 'txt':
+            if sca_options.get_color_opt():
+                output_type = 'color'
 
-	if sca_options.get_file_name() is not None:
-		outfile = sca_options.get_file_name()
-	else:
-		outfile = sys.stdout;
+        if sca_options.get_file_name() is not None:
+            try:
+                outfile = open(sca_options.get_file_name(),'w')
+            except:
+                sys.stdout.write("Unable to open \"%s\" for writing.\n" % sca_options.get_file_name())
+                sys.exit(1)
+        else:
+            outfile = sys.stdout;
 
-	core.output_sca(group_problems, outfile, output_type)
+        core.output_sca(group_problems, outfile, output_type)
 
 def check_exit_status(status):
     """

--- a/sca/controller.py
+++ b/sca/controller.py
@@ -59,17 +59,21 @@ def run_sca(binary_path, binary_args, sca_options):
             sys.stdout.write("\nSCA report: No reports found.")
             sys.exit(0)
 
-        if sca_options.get_file_type_opt() is not None:
-            ok_val = core.save_sca(group_problems, sca_options.get_file_name(),
-                                   sca_options.get_file_type_opt())
-            if not ok_val:
-                print "\nSCA report: An error happened when saving the file.\n"
-            else:
-                print "\nSCA report was saved in file: ",
-                print sca_options.get_file_name() + '\n'
-        else:
-            core.print_sca(group_problems, sca_options.get_color_opt())
+	if sca_options.get_file_type_opt() is None:
+		sca_options.set_file_type_opt('txt')
 
+	output_type = sca_options.get_file_type_opt()
+
+	if output_type == 'txt':
+		if sca_options.get_color_opt():
+			output_type = 'color'
+
+	if sca_options.get_file_name() is not None:
+		outfile = sca_options.get_file_name()
+	else:
+		outfile = sys.stdout;
+
+	core.output_sca(group_problems, outfile, output_type)
 
 def check_exit_status(status):
     """

--- a/sca/core.py
+++ b/sca/core.py
@@ -108,7 +108,7 @@ def cmdexists(command):
     return subp == 0
 
 
-def print_output(msg_type, flag, msg):
+def print_output(outfile, msg_type, flag, msg):
     """ SCA print function, enables color usage """
     color_open = ''
     color_close = ''
@@ -122,21 +122,21 @@ def print_output(msg_type, flag, msg):
         if msg_type == 'WARNING':
             color_open = "{hiyellow}"
             color_close = "{/hiyellow}"
-    print Color(color_open + msg + color_close)
+    outfile.write(Color(color_open + msg + color_close))
 
 
-def print_sca(problems_dict, color_flag):
-    ''' This function shows events info '''
+def output_sca_txt(problems_dict, output_file, color_flag):
+    ''' This function emits events in txt format '''
     for key in problems_dict:
         problem = problems_dict.get(key)
-        msg_problem = "\n[Problem: {}]".format(problem.get_name_problem())
-        print_output('ERROR', color_flag, msg_problem)
+        msg_problem = "\n[Problem: {}]\n".format(problem.get_name_problem())
+        print_output(output_file, 'ERROR', color_flag, msg_problem)
         problem_description = problem.get_problem_description()
-        msg_descript = "[Description: {}]".format(problem_description)
-        print_output('ERROR', color_flag, msg_descript)
+        msg_descript = "[Description: {}]\n".format(problem_description)
+        print_output(output_file, 'ERROR', color_flag, msg_descript)
 
-        print_output('INFO', color_flag, "[Solution:")
-        print_output('INFO', color_flag, problem.get_solution())
+        print_output(output_file, 'INFO', color_flag, "[Solution:")
+        print_output(output_file, 'INFO', color_flag, problem.get_solution() + '\n')
 
         for file_inf in problems_dict[key].get_file_info_list():
             file_name = file_inf.get_file_name()
@@ -151,60 +151,27 @@ def print_sca(problems_dict, color_flag):
             function = "Function: %s" % (function_name)
             ip_add = "Instruction Pointer: %s" % (address)
 
-            msg_ref = "[%s%s | %s] " % (reference, function, ip_add)
-            print_output('WARNING', color_flag, msg_ref)
-        print "-------------------------------------------------------"
+            msg_ref = "[%s%s | %s]\n" % (reference, function, ip_add)
+            print_output(output_file, 'WARNING', color_flag, msg_ref)
 
 
-def save_sca_txt(problems_dict, file_name):
-    ''' This function saves events info in a txt file'''
-    with open(file_name, 'w') as output_file:
-        for key in problems_dict:
-            problem = problems_dict.get(key)
-            output_file.write("[Problem: {}]\n".format(
-                problem.get_name_problem()))
-            output_file.write("[Description: {}]\n".format(
-                problem.get_problem_description()))
-
-            output_file.write("[Solution:\n")
-            output_file.write(problem.get_solution() + "\n]")
-            output_file.write("\n")
-            for file_inf in problems_dict[key].get_file_info_list():
-                file_name = file_inf.get_file_name()
-                line = file_inf.get_line()
-                function_name = file_inf.get_function()
-                address = file_inf.get_address()
-
-                # Dont show if dont have line number information
-                reference = ""
-                if line != "0":
-                    reference = "Reference: %s:%s | " % (file_name, line)
-                function = "Function: %s" % (function_name)
-                ip_address = "Instruction Pointer: %s" % (address)
-
-                output_file.write("[%s%s | %s] \n" % (reference, function,
-                                                      ip_address))
-            output_file.write("\n")
-            for symbol in range(0, 56):
-                output_file.write("-"),
-            output_file.write("\n")
-
-
-def save_sca_json(problems_dict, file_name):
+def output_sca_json(problems_dict, outfile):
     '''This function saves events info in a Json file'''
-    with open(file_name, 'w') as outfile:
-        for key in problems_dict:
-            outfile.write(problems_dict.get(key).to_json())
+    for key in problems_dict:
+        outfile.write(problems_dict.get(key).to_json())
 
 
-def save_sca(problems_dict, file_name, file_type):
+def output_sca(problems_dict, outfile, file_type):
     '''This function saves events in a file'''
     ret_val = False
     if file_type == 'txt':
-        save_sca_txt(problems_dict, file_name)
+        output_sca_txt(problems_dict, outfile, False)
+        ret_val = True
+    elif file_type == 'color':
+        output_sca_txt(problems_dict, outfile, True)
         ret_val = True
     elif file_type == 'json':
-        save_sca_json(problems_dict, file_name)
+        output_sca_json(problems_dict, outfile)
         ret_val = True
     return ret_val
 

--- a/sca/sca.py
+++ b/sca/sca.py
@@ -23,7 +23,6 @@ limitations under the License.
 
 import sys
 import os
-import time
 import argparse
 
 from argparse import ArgumentParser
@@ -84,11 +83,6 @@ class ScaOptions(object):
     def set_color_opt(self, color_opt):
         ''' Set color option'''
         self.color_opt = color_opt
-
-
-def get_timestamp():
-    ''' Return the current timestamp '''
-    return time.strftime("%Y%m%d%H%M%S")
 
 
 def main(argv=None):
@@ -163,16 +157,12 @@ def main(argv=None):
             sca_options.set_file_type_opt(args.file_type)
             if args.file_name is not None:
                 sca_options.set_file_name(args.file_name)
-            else:
-                fname = 'sca_report_' + get_timestamp() + '.' + args.file_type
-                sca_options.set_file_name(fname)
         elif args.file_name is not None:
             if not args.file_name:
                 print "Please set a file name"
                 return
             sca_options.set_file_type_opt('txt')
-            sca_options.set_file_name(args.file_name + '.' +
-                                      sca_options.get_file_type_opt())
+
         # Run SCA
         controller.run_sca(binary_path, binary_args, sca_options)
     except KeyboardInterrupt:

--- a/sca/sca.py
+++ b/sca/sca.py
@@ -115,8 +115,6 @@ def main(argv=None):
                                 formatter_class=RawTextHelpFormatter)
         parser.add_argument('--version', '-V', action='version',
                             version=program_version_message)
-        parser.add_argument('--color', dest="color", action='store_true',
-                            help="displays results in color\n\n")
         parser.add_argument("--fdprpro-args", dest="fdprpro_args", type=str,
                             help="fdprpro options \n"
                             "e.g.: --fdprpro-args='-O3 -v 3'\n"
@@ -128,11 +126,14 @@ def main(argv=None):
                             "e.g.:--output-type=txt\n\n",
                             default=None, choices=['txt', 'json'],
                             nargs='?')
-        parser.add_argument("--output-name", dest="file_name", type=str,
+        group = parser.add_mutually_exclusive_group()
+        group.add_argument("--output-name", dest="file_name", type=str,
                             help="The name of the report file\n"
                             "e.g.: --output-name=file_name\n\n",
                             default=None,
                             nargs='?')
+        group.add_argument('--color', dest="color", action='store_true',
+                            help="displays results in color\n\n")
         parser.add_argument(dest="cmd",
                             metavar="COMMAND",
                             help="the application and its arguments\n"
@@ -154,6 +155,9 @@ def main(argv=None):
             if args.file_type not in ('txt', 'json'):
                 print "File type not supported"
                 return
+            if args.file_type == 'json' and args.color:
+                print "JSON output does not support --color"
+		return
             sca_options.set_file_type_opt(args.file_type)
             if args.file_name is not None:
                 sca_options.set_file_name(args.file_name)


### PR DESCRIPTION
By default, output will go to stdout.
Also, remove automatic file name generation.
Output destination is either explicitly specified, or will be stdout.

Signed-off-by: Paul A. Clarke <pc@us.ibm.com>